### PR TITLE
Added `public` and `private` suffixes accordingly to subnet types

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,13 +22,13 @@ you plan to use new (separate) VPC.
 module "subnets" {
   source = "git::https://github.com/cloudposse/tf_subnets.git?ref=master"
 
-  availability_zones      = "${var.availability_zones}"
-  namespace               = "${var.namespace}"
-  name                    = "${var.name}"
-  stage                   = "${var.stage}"
-  region                  = "${var.region}"
-  vpc_id                  = "${var.vpc_id}"
-  igw_id                  = "${var.igw_id}"
+  availability_zones         = "${var.availability_zones}"
+  namespace                  = "${var.namespace}"
+  name                       = "${var.name}"
+  stage                      = "${var.stage}"
+  region                     = "${var.region}"
+  vpc_id                     = "${var.vpc_id}"
+  igw_id                     = "${var.igw_id}"
   vpc_default_route_table_id = "${var.vpc_default_route_table_id}"
 }
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ you plan to use new (separate) VPC.
 * `vpc_default_route_table_id`: A default route table for public subnets. Provides access to Internet. If not set here - will be created.
 
 ```
-module "tf_subnets" {
+module "subnets" {
   source = "git::https://github.com/cloudposse/tf_subnets.git?ref=master"
 
   availability_zones      = "${var.availability_zones}"
@@ -32,3 +32,16 @@ module "tf_subnets" {
   vpc_default_route_table_id = "${var.vpc_default_route_table_id}"
 }
 ```
+
+## Variables
+
+|  Name                        |  Default       |  Description                                              | Required |
+|:----------------------------:|:--------------:|:--------------------------------------------------------:|:--------:|
+| namespace                    | ``             | Namespace (e.g. `cp` or `cloudposse`)                    | Yes      |
+| stage                        | ``             | Stage (e.g. `prod`, `dev`, `staging`)                     | Yes      |
+| name                         | ``             | Name  (e.g. `bastion` or `db`)                           | Yes      |
+| region                       | ``             | AWS Region where module should operate (e.g. `us-east-1`)| Yes      |
+| vpc_id                       | ``             | The VPC ID where subnets will be created (e.g. `vpc-aceb2723`)         | Yes      |
+| igw_id                       | ``             | The Internet Gateway ID public route table will point to (e.g. `igw-9c26a123`) | Yes       |
+| vpc_default_route_table_id   | ``             | The scheduling expression. (e.g. cron(0 20 * * ? *) or rate(5 minutes) | No       |
+| availability_zones           | []             | The scheduling expression. (e.g. cron(0 20 * * ? *) or rate(5 minutes) | Yes       |

--- a/main.tf
+++ b/main.tf
@@ -6,13 +6,6 @@ provider "aws" {
   region = "${var.region}"
 }
 
-module "tf_label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.1.0"
-  namespace = "${var.namespace}"
-  stage     = "${var.stage}"
-  name      = "${var.name}"
-}
-
 # Get object aws_vpc by vpc_id
 data "aws_vpc" "default" {
   id = "${var.vpc_id}"

--- a/private.tf
+++ b/private.tf
@@ -1,10 +1,17 @@
+module "private_label" {
+  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.1.0"
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+  name      = "${var.name}-private"
+}
+
 resource "aws_subnet" "private" {
   count = "${length(var.availability_zones)}"
 
   vpc_id            = "${data.aws_vpc.default.id}"
   availability_zone = "${element(var.availability_zones, count.index)}"
   cidr_block        = "${cidrsubnet(data.aws_vpc.default.cidr_block, length(var.availability_zones), length(var.availability_zones)  + count.index)}"
-  tags              = "${module.tf_label.tags}"
+  tags              = "${module.private_label.tags}"
 }
 
 resource "aws_route_table" "private" {
@@ -16,7 +23,7 @@ resource "aws_route_table" "private" {
     nat_gateway_id = "${element(aws_nat_gateway.default.*.id, count.index)}"
   }
 
-  tags = "${module.tf_label.tags}"
+  tags = "${module.private_label.tags}"
 }
 
 resource "aws_route_table_association" "private" {

--- a/public.tf
+++ b/public.tf
@@ -1,3 +1,10 @@
+module "public_label" {
+  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.1.0"
+  namespace = "${var.namespace}"
+  stage     = "${var.stage}"
+  name      = "${var.name}-public"
+}
+
 resource "aws_subnet" "public" {
   count = "${length(var.availability_zones)}"
 
@@ -5,7 +12,7 @@ resource "aws_subnet" "public" {
   availability_zone = "${element(var.availability_zones, count.index)}"
   cidr_block        = "${cidrsubnet(data.aws_vpc.default.cidr_block, length(var.availability_zones), count.index)}"
 
-  tags = "${module.tf_label.tags}"
+  tags = "${module.public_label.tags}"
 }
 
 resource "aws_route_table" "public" {
@@ -16,7 +23,7 @@ resource "aws_route_table" "public" {
     cidr_block = "0.0.0.0/0"
     gateway_id = "${var.igw_id}"
   }
-  tags = "${module.tf_label.tags}"
+  tags = "${module.public_label.tags}"
 }
 
 resource "aws_route_table_association" "public" {


### PR DESCRIPTION
## What

* Added `public` and `private` suffixes to subnet names accordingly to subnet types

## Why

* We need an option to easily distinguish private and public subnets

## Plan

![1502811751675](https://user-images.githubusercontent.com/11299538/29323417-873de9b6-81e9-11e7-8b85-0e26064e0bcf.png)
