### PR TITLE
Add Outputs for public & private subnet ids

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # Module directory
 .terraform/
+
+.idea
+*.iml

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ data "aws_vpc" "default" {
   id = "${var.vpc_id}"
 }
 
-# Get all subnets from the necessary vpc
+# Get all subnets from the VPC
 data "aws_subnet_ids" "all" {
   vpc_id = "${data.aws_vpc.default.id}"
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,7 @@
+output "public_subnets" {
+  value = ["${aws_subnet.public.*.id}"]
+}
+
+output "private_subnets" {
+  value = ["${aws_subnet.private.*.id}"]
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,7 +1,7 @@
-output "public_subnets" {
+output "public_subnet_ids" {
   value = ["${aws_subnet.public.*.id}"]
 }
 
-output "private_subnets" {
+output "private_subnet_ids" {
   value = ["${aws_subnet.private.*.id}"]
 }


### PR DESCRIPTION
## What

* Added `outputs.tf` for public & private subnet ids

## Why

* To use the module from other modules, we need to know the private and public subnets need to be accessible
