### PR TITLE
Update required Terraform version to 0.10.1

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = ">= 0.10.0"
+  required_version = "~> 0.10.1"
 }
 
 provider "aws" {

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.9.1"
+  required_version = ">= 0.10.0"
 }
 
 provider "aws" {


### PR DESCRIPTION
## What
* Changed the required version of Terraform

## Why
* Terraform version is lower than 0.10.0 does not support datasource `aws_internet_gateway`