### PR TITLE
Remove `data "aws_subnet_ids"`

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,8 +10,3 @@ provider "aws" {
 data "aws_vpc" "default" {
   id = "${var.vpc_id}"
 }
-
-# Get all subnets from the VPC
-data "aws_subnet_ids" "all" {
-  vpc_id = "${data.aws_vpc.default.id}"
-}


### PR DESCRIPTION
## What

* Remove `data "aws_subnet_ids"` from `main.tf`


## Why

* It's not used and breaks on new VPCs without existing subnets
