### PR TITLE
Add `nat_gateway_eip_enabled` variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,14 @@ You should use [tf_vpc](https://github.com/cloudposse/tf_vpc) module if
 you plan to use new (separate) VPC.
 
 * `availability_zones`: (Required) List of AZ.
-* `name`: (Required) Name of these resources
-* `region`: (Required) AWS region. Used to find remote state.
-* `stage`: (Required) Stage associated with these resources
-* `namespace`: (Required) Namespace associated with these resources
+* `name`: (Required) Name of these resources.
+* `region`: (Required) AWS Region where the module should operate.
+* `stage`: (Required) Stage associated with these resources.
+* `namespace`: (Required) Namespace associated with these resources.
 * `vpc_id`: (Required) AWS Virtual Private Cloud ID.
 * `igw_id`: (Required) AWS Internet Gateway for public subnets. Only one igw can be attached to a VPC.
-* `vpc_default_route_table_id`: A default route table for public subnets. Provides access to Internet. If not set here - will be created.
+* `vpc_default_route_table_id`: (Optional) A default route table for public subnets. Provides access to the Internet. If not set here, will be created.
+* `nat_gateway_eip_enabled`: (Optional) Controls the creation of Elastic IPs, NAT Gateways, and Route Tables for private subnets. The default value is 'true'. If not explicitly set to 'false', Elastic IPs, NAT Gateways, and Route Tables for all private subnets will be created.
 
 ```
 module "subnets" {
@@ -30,6 +31,7 @@ module "subnets" {
   vpc_id                     = "${var.vpc_id}"
   igw_id                     = "${var.igw_id}"
   vpc_default_route_table_id = "${var.vpc_default_route_table_id}"
+  nat_gateway_eip_enabled    = "${var.nat_gateway_eip_enabled}"
 }
 ```
 
@@ -40,8 +42,9 @@ module "subnets" {
 | namespace                    | ``             | Namespace (e.g. `cp` or `cloudposse`)                    | Yes      |
 | stage                        | ``             | Stage (e.g. `prod`, `dev`, `staging`)                     | Yes      |
 | name                         | ``             | Name  (e.g. `bastion` or `db`)                           | Yes      |
-| region                       | ``             | AWS Region where module should operate (e.g. `us-east-1`)| Yes      |
-| vpc_id                       | ``             | The VPC ID where subnets will be created (e.g. `vpc-aceb2723`)         | Yes      |
-| igw_id                       | ``             | The Internet Gateway ID public route table will point to (e.g. `igw-9c26a123`) | Yes       |
-| vpc_default_route_table_id   | ``             | The scheduling expression. (e.g. cron(0 20 * * ? *) or rate(5 minutes) | No       |
-| availability_zones           | []             | The scheduling expression. (e.g. cron(0 20 * * ? *) or rate(5 minutes) | Yes       |
+| region                       | ``             | AWS Region where the module should operate (e.g. `us-east-1`)| Yes      |
+| vpc_id                       | ``             | The VPC ID where the subnets will be created (e.g. `vpc-aceb2723`)         | Yes      |
+| igw_id                       | ``             | The Internet Gateway ID the public route table will point to (e.g. `igw-9c26a123`) | Yes       |
+| availability_zones           | []             | List of AZ | Yes       |
+| vpc_default_route_table_id   | ``             | A default route table for public subnets. Provides access to the Internet. If not set here, will be created. | No       |
+| nat_gateway_eip_enabled      | `true`         | Controls the creation of Elastic IPs, NAT Gateways, and Route Tables for private subnets. If not set to 'false', Elastic IPs, NAT Gateways, and Route Tables for all private subnets will be created. | No       |

--- a/gws.tf
+++ b/gws.tf
@@ -1,5 +1,5 @@
 resource "aws_eip" "default" {
-  count = "${var.nat_gateway_eip_enabled == 1 ? 0 : length(var.availability_zones)}"
+  count = "${var.nat_gateway_eip_enabled == true ? 0 : length(var.availability_zones)}"
   vpc   = true
 
   lifecycle {
@@ -8,7 +8,7 @@ resource "aws_eip" "default" {
 }
 
 resource "aws_nat_gateway" "default" {
-  count         = "${var.nat_gateway_eip_enabled == 1 ? 0 : length(var.availability_zones)}"
+  count         = "${var.nat_gateway_eip_enabled == true ? 0 : length(var.availability_zones)}"
   allocation_id = "${element(aws_eip.default.*.id, count.index)}"
   subnet_id     = "${element(aws_subnet.private.*.id, count.index)}"
 

--- a/gws.tf
+++ b/gws.tf
@@ -1,5 +1,5 @@
 resource "aws_eip" "default" {
-  count = "${length(var.availability_zones)}"
+  count = "${var.nat_gateway_eip_enabled == 1 ? 0 : length(var.availability_zones)}"
   vpc   = true
 
   lifecycle {
@@ -8,7 +8,7 @@ resource "aws_eip" "default" {
 }
 
 resource "aws_nat_gateway" "default" {
-  count         = "${length(var.availability_zones)}"
+  count         = "${var.nat_gateway_eip_enabled == 1 ? 0 : length(var.availability_zones)}"
   allocation_id = "${element(aws_eip.default.*.id, count.index)}"
   subnet_id     = "${element(aws_subnet.private.*.id, count.index)}"
 

--- a/private.tf
+++ b/private.tf
@@ -15,7 +15,7 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_route_table" "private" {
-  count  = "${var.nat_gateway_eip_enabled == 1 ? 0 : length(var.availability_zones)}"
+  count  = "${var.nat_gateway_eip_enabled == true ? 0 : length(var.availability_zones)}"
   vpc_id = "${data.aws_vpc.default.id}"
 
   route {
@@ -27,7 +27,7 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_route_table_association" "private" {
-  count          = "${var.nat_gateway_eip_enabled == 1 ? 0 : length(var.availability_zones)}"
+  count          = "${var.nat_gateway_eip_enabled == true ? 0 : length(var.availability_zones)}"
 
   subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
   route_table_id = "${element(aws_route_table.private.*.id, count.index)}"

--- a/private.tf
+++ b/private.tf
@@ -6,7 +6,7 @@ module "private_label" {
 }
 
 resource "aws_subnet" "private" {
-  count = "${length(var.availability_zones)}"
+  count             = "${length(var.availability_zones)}"
 
   vpc_id            = "${data.aws_vpc.default.id}"
   availability_zone = "${element(var.availability_zones, count.index)}"
@@ -15,7 +15,7 @@ resource "aws_subnet" "private" {
 }
 
 resource "aws_route_table" "private" {
-  count  = "${length(var.availability_zones)}"
+  count  = "${var.nat_gateway_eip_enabled == 1 ? 0 : length(var.availability_zones)}"
   vpc_id = "${data.aws_vpc.default.id}"
 
   route {
@@ -23,11 +23,11 @@ resource "aws_route_table" "private" {
     nat_gateway_id = "${element(aws_nat_gateway.default.*.id, count.index)}"
   }
 
-  tags = "${module.private_label.tags}"
+  tags   = "${module.private_label.tags}"
 }
 
 resource "aws_route_table_association" "private" {
-  count = "${length(var.availability_zones)}"
+  count          = "${var.nat_gateway_eip_enabled == 1 ? 0 : length(var.availability_zones)}"
 
   subnet_id      = "${element(aws_subnet.private.*.id, count.index)}"
   route_table_id = "${element(aws_route_table.private.*.id, count.index)}"

--- a/variables.tf
+++ b/variables.tf
@@ -31,5 +31,5 @@ variable "vpc_default_route_table_id" {
 }
 
 variable "nat_gateway_eip_enabled" {
-  default = 1
+  default = true
 }

--- a/variables.tf
+++ b/variables.tf
@@ -29,3 +29,7 @@ variable "igw_id" {
 variable "vpc_default_route_table_id" {
   default = ""
 }
+
+variable "nat_gateway_eip_enabled" {
+  default = 1
+}


### PR DESCRIPTION
## What

* Add `nat_gateway_eip_enabled` variable to control the creation of Elastic IPs and NAT Gateways for private subnets


## Why

* In some environments like Elastic Beanstalk with a simple app deployed behind a public load balancer, we don't need to create NAT gateways and Elastic IPs for private subnets
