### PR TITLE
Place NAT Gateways into public subnets

### DIFF
--- a/gws.tf
+++ b/gws.tf
@@ -10,7 +10,7 @@ resource "aws_eip" "default" {
 resource "aws_nat_gateway" "default" {
   count         = "${length(var.availability_zones)}"
   allocation_id = "${element(aws_eip.default.*.id, count.index)}"
-  subnet_id     = "${element(aws_subnet.private.*.id, count.index)}"
+  subnet_id     = "${element(aws_subnet.public.*.id, count.index)}"
 
   lifecycle {
     create_before_destroy = true


### PR DESCRIPTION
## What

* Place NAT Gateways into public subnets


## Why

* NAT Gateways need to be in public subnets in order to be able to access the Internet
