### PR TITLE
Get the Internet Gateway attached to the VPC from AWS as a data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ you plan to use new (separate) VPC.
 * `stage`: (Required) Stage associated with these resources
 * `namespace`: (Required) Namespace associated with these resources
 * `vpc_id`: (Required) AWS Virtual Private Cloud ID.
-* `igw_id`: (Required) AWS Internet Gateway for public subnets. Only one igw can be attached to a VPC.
 * `vpc_default_route_table_id`: A default route table for public subnets. Provides access to Internet. If not set here - will be created.
 
 ```
@@ -28,7 +27,6 @@ module "subnets" {
   stage                      = "${var.stage}"
   region                     = "${var.region}"
   vpc_id                     = "${var.vpc_id}"
-  igw_id                     = "${var.igw_id}"
   cidr_block                 = "${var.cidr_block}"
   vpc_default_route_table_id = "${var.vpc_default_route_table_id}"
 }
@@ -43,7 +41,6 @@ module "subnets" {
 | name                         | ``             | Name  (e.g. `bastion` or `db`)                                                                                                       | Yes      |
 | region                       | ``             | AWS Region where module should operate (e.g. `us-east-1`)                                                                            | Yes      |
 | vpc_id                       | ``             | The VPC ID where subnets will be created (e.g. `vpc-aceb2723`)                                                                       | Yes      |
-| igw_id                       | ``             | The Internet Gateway ID public route table will point to (e.g. `igw-9c26a123`)                                                       | Yes      |
 | cidr_block                   | ``             | The base CIDR block which will be divided into subnet CIDR blocks (e.g. `10.0.0.0/16`)                                               | Yes      |
 | vpc_default_route_table_id   | ``             | The default route table for public subnets. Provides access to the Internet. If not set here, will be created. (e.g. `rtb-f4f0ce12`) | No       |
 | availability_zones           | []             | The list of Availability Zones where subnets will be created (e.g. `["us-eas-1a", "us-eas-1b"]`)                                     | Yes      |

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 0.10.1"
+  required_version = "~> 0.10.2"
 }
 
 provider "aws" {
@@ -12,3 +12,14 @@ data "aws_vpc" "default" {
 }
 
 data "aws_availability_zones" "available" {}
+
+
+# Get the Internet Gateway attached to the VPC
+# https://www.terraform.io/docs/providers/aws/d/internet_gateway.html
+# https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInternetGateways.html
+data "aws_internet_gateway" "default" {
+  filter {
+    name   = "attachment.vpc-id"
+    values = ["${var.vpc_id}"]
+  }
+}

--- a/main.tf
+++ b/main.tf
@@ -13,7 +13,6 @@ data "aws_vpc" "default" {
 
 data "aws_availability_zones" "available" {}
 
-
 # Get the Internet Gateway attached to the VPC
 # https://www.terraform.io/docs/providers/aws/d/internet_gateway.html
 # https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInternetGateways.html

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,3 @@ output "public_subnet_ids" {
 output "private_subnet_ids" {
   value = ["${aws_subnet.private.*.id}"]
 }
-
-output "test" {
-  value = "${data.aws_availability_zones.available.count}"
-}

--- a/public.tf
+++ b/public.tf
@@ -6,12 +6,12 @@ module "public_label" {
 }
 
 resource "aws_subnet" "public" {
-  count = "${length(var.availability_zones)}"
+  count             = "${length(var.availability_zones)}"
 
   vpc_id            = "${data.aws_vpc.default.id}"
   availability_zone = "${element(var.availability_zones, count.index)}"
 
-  cidr_block = "${
+  cidr_block        = "${
     cidrsubnet(
     signum(length(var.cidr_block)) == 1 ?
     var.cidr_block : data.aws_vpc.default.cidr_block,
@@ -19,7 +19,7 @@ resource "aws_subnet" "public" {
     length(data.aws_availability_zones.available.names) + count.index)
   }"
 
-  tags = "${module.public_label.tags}"
+  tags              = "${module.public_label.tags}"
 }
 
 resource "aws_route_table" "public" {
@@ -28,10 +28,10 @@ resource "aws_route_table" "public" {
 
   route {
     cidr_block = "0.0.0.0/0"
-    gateway_id = "${var.igw_id}"
+    gateway_id = "${data.aws_internet_gateway.default.id}"
   }
 
-  tags = "${module.public_label.tags}"
+  tags   = "${module.public_label.tags}"
 }
 
 resource "aws_route_table_association" "public" {

--- a/public.tf
+++ b/public.tf
@@ -6,12 +6,12 @@ module "public_label" {
 }
 
 resource "aws_subnet" "public" {
-  count             = "${length(var.availability_zones)}"
+  count = "${length(var.availability_zones)}"
 
   vpc_id            = "${data.aws_vpc.default.id}"
   availability_zone = "${element(var.availability_zones, count.index)}"
 
-  cidr_block        = "${
+  cidr_block = "${
     cidrsubnet(
     signum(length(var.cidr_block)) == 1 ?
     var.cidr_block : data.aws_vpc.default.cidr_block,
@@ -19,7 +19,7 @@ resource "aws_subnet" "public" {
     length(data.aws_availability_zones.available.names) + count.index)
   }"
 
-  tags              = "${module.public_label.tags}"
+  tags = "${module.public_label.tags}"
 }
 
 resource "aws_route_table" "public" {
@@ -31,7 +31,7 @@ resource "aws_route_table" "public" {
     gateway_id = "${data.aws_internet_gateway.default.id}"
   }
 
-  tags   = "${module.public_label.tags}"
+  tags = "${module.public_label.tags}"
 }
 
 resource "aws_route_table_association" "public" {

--- a/variables.tf
+++ b/variables.tf
@@ -26,10 +26,6 @@ variable "availability_zones" {
   type = "list"
 }
 
-variable "igw_id" {
-  default = ""
-}
-
 variable "vpc_default_route_table_id" {
   default = ""
 }


### PR DESCRIPTION
## What

* Get the Internet Gateway attached to the VPC from AWS

## Why

* Since only one Internet Gateway could be attached to a VPC (and we suppose it's already attached since we use its ID), we can get its ID from AWS instead of manually defining it in `variables.tf`


## References

* https://www.terraform.io/docs/providers/aws/d/internet_gateway.html
* https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_DescribeInternetGateways.html

