### PR TITLE
Add route table IDs outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -6,6 +6,10 @@ output "private_subnet_ids" {
   value = ["${aws_subnet.private.*.id}"]
 }
 
+output "public_route_table_ids" {
+  value = ["${aws_route_table.public.*.id}"]
+}
+
 output "private_route_table_ids" {
   value = ["${aws_route_table.private.*.id}"]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,3 +5,7 @@ output "public_subnet_ids" {
 output "private_subnet_ids" {
   value = ["${aws_subnet.private.*.id}"]
 }
+
+output "private_route_table_ids" {
+  value = ["${aws_route_table.private.*.id}"]
+}


### PR DESCRIPTION
## What
* Added `id` of private route tables to the `output`

## Why
* We need option to add additional routes to route tables
